### PR TITLE
Latest of version of Suricata that will run without exception with mu…

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM cccs/assemblyline-v4-service-base:latest AS base
 
 ENV SERVICE_PATH suricata_.suricata_.Suricata
-ENV SURICATA_VERSION 4.1.2
+ENV SURICATA_VERSION 4.1.4
 
 USER root
 


### PR DESCRIPTION
…ltiple sources

Tested with emt and ETPro on dev machine running in a container.

Should be able to resolve in the logs similar to:

Suricata will load the following rule files: ['Suricata/Suricata_2020-08-19T144427.394803Z/suricata/emt', 'Suricata/Suricata_2020-08-19T154720.233807Z/suricata/emt', 'Suricata/Suricata_2020-08-19T154720.233807Z/suricata/ETPRO']
...
Ruleset 0: 50327 rules loaded
Ruleset 0: 36424 rules failed to load
