### PR TITLE
Add more logging to suricata.log, doesn't affect service function

### DIFF
--- a/suricata_/suricata_.py
+++ b/suricata_/suricata_.py
@@ -180,6 +180,7 @@ class Suricata(ServiceBase):
         if not os.path.exists(self.suricata_socket):
             command = [
                 SURICATA_BIN,
+                "-vvvv",  # Useful for debugging
                 "-c", self.suricata_yaml,
                 f"--unix-socket={self.suricata_socket}",
                 "--pidfile", f"{self.run_dir}/suricata.pid",


### PR DESCRIPTION
Will help diagnose current Suricata issue, could be memory-related causing Suricata to kill itself while loading ET rules

This was the state in dev, however dev didn't crash like malware or staging:
![image](https://user-images.githubusercontent.com/62077998/93247468-53035280-f75c-11ea-8cb4-34946e6b0c50.png)
