### PR TITLE
Adding an extra 0.5GB of memory

### DIFF
--- a/service_manifest.yml
+++ b/service_manifest.yml
@@ -49,7 +49,7 @@ heuristics:
 docker_config:
   image: ${REGISTRY}cccs/assemblyline-service-suricata:$SERVICE_TAG
   cpu_cores: 1
-  ram_mb: 1024
+  ram_mb: 2048
 
 update_config:
   generates_signatures: true

--- a/service_manifest.yml
+++ b/service_manifest.yml
@@ -49,7 +49,7 @@ heuristics:
 docker_config:
   image: ${REGISTRY}cccs/assemblyline-service-suricata:$SERVICE_TAG
   cpu_cores: 1
-  ram_mb: 2048
+  ram_mb: 1536
 
 update_config:
   generates_signatures: true


### PR DESCRIPTION
kernel is killing Suricata process maybe due to lack of available memory?

Imposing the same memory limits (or less) on Docker doesn't replicate the same error, just causes Suricata to take longer to load the rules..