### PR TITLE
Upgrade Suricata to 6.0.2 (latest)

### DIFF
--- a/suricata_/suricata_.py
+++ b/suricata_/suricata_.py
@@ -26,7 +26,7 @@ class Suricata(ServiceBase):
         super(Suricata, self).__init__(config)
 
         self.home_net = self.config.get("home_net", "any")
-        self.rules_config = yaml.safe_dump({"rule_files": []})
+        self.rules_config = yaml.safe_dump({"rule-files": []})
         self.rules_list = []
         self.run_dir = "/var/run/suricata"
         self.suricata_socket = None
@@ -165,6 +165,8 @@ class Suricata(ServiceBase):
         try:
             self.suricata_sc.connect()
         except suricatasc.SuricataException as e:
+            if "Transport endpoint is already connected" in str(e):
+                return True
             self.log.info(f"Suricata not started yet: {str(e)}")
             return False
         return True


### PR DESCRIPTION
Related to: https://cccs.atlassian.net/browse/AL-176

Dockerfile has been reworked to build a stable Suricata. 

Notable changes are:
- using rustup instead of Debian rust package due to bug found during Suricata build
- changing rule_files to rule-files (deprecation)
- ENV LD_LIBRARY_PATH=/usr/local/lib to indicate the location of the libhtp (default=/usr/lib)
- Change to service code when exception is raised but indicates Suricata is running and therefore should proceed