### PR TITLE
Filter out common link-local IPv6 addresses

### DIFF
--- a/suricata_/suricata_.py
+++ b/suricata_/suricata_.py
@@ -564,6 +564,10 @@ class Suricata(ServiceBase):
                     or ip.startswith("192.168.")
                     or ip.startswith("10.")
                     or (ip.startswith("172.") and 16 <= int(ip.split(".")[1]) <= 31)
+                    # Link-local IPv6 addresses
+                    or ip.startswith("fe80:0000:0000:0000:")
+                    # All-routers link-local multicast
+                    or ip != "ff02:0000:0000:0000:0000:0000:0000:0002"
                 ):
                     ip_section.add_line(ip)
                     ip_section.add_tag("network.dynamic.ip", ip)

--- a/suricata_/suricata_.py
+++ b/suricata_/suricata_.py
@@ -567,7 +567,7 @@ class Suricata(ServiceBase):
                     # Link-local IPv6 addresses
                     or ip.startswith("fe80:0000:0000:0000:")
                     # All-routers link-local multicast
-                    or ip != "ff02:0000:0000:0000:0000:0000:0000:0002"
+                    or ip == "ff02:0000:0000:0000:0000:0000:0000:0002"
                 ):
                     ip_section.add_line(ip)
                     ip_section.add_tag("network.dynamic.ip", ip)


### PR DESCRIPTION
The service currently filters out local IPv4 addresses,
but leaves all IPv6. This change prevents Suricata from
producing IPv6 addresses that aren't routable externally.

For reference, see https://en.wikipedia.org/wiki/IPv6_address#Local_addresses

Context:

I have a service producing PCAP with the network traffic, but among interesting connections, there are always a few standard IPv6 addresses. They are not used to move any traffic, but to exchange automated network configuration information. Link-local in IPv6 is also similar to local addresses in IPv4.