### PR TITLE
Change retrying code to use Tenacity instead

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,8 @@ Organizations can add their own rulesets to this service.
 
 ## Test if working
 
- Just inside the container run:
- 
-        python -m assemblyline_v4_service.dev.run_service_once suricata_.suricata_.Suricata /tmp/testing.pcap
+Inside the container run:
+
+```bash
+python -m assemblyline_v4_service.dev.run_service_once suricata_.suricata_.Suricata /tmp/testing.pcap
+```

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,4 +4,4 @@ python-dateutil
 suricata-update
 suricataparser
 async_timeout
-retrying
+tenacity

--- a/suricata_/suricata_.py
+++ b/suricata_/suricata_.py
@@ -16,7 +16,7 @@ from assemblyline.odm.models.ontology.results import Signature
 from assemblyline_v4_service.common.base import ServiceBase
 from assemblyline_v4_service.common.request import MaxExtractedExceeded
 from assemblyline_v4_service.common.result import BODY_FORMAT, Result, ResultSection
-from retrying import RetryError, retry
+from tenacity import RetryError, retry
 
 from suricata_.helper import parse_suricata_output
 

--- a/suricata_/suricata_.py
+++ b/suricata_/suricata_.py
@@ -179,7 +179,7 @@ class Suricata(ServiceBase):
     @retry(
         retry=retry_if_result(lambda x: x is False),
         wait=wait_exponential(multiplier=1000, max=10000),
-        stop=stop_after_delay(120000)
+        stop=stop_after_delay(120000),
     )
     def suricata_running_retry(self):
         return self.suricata_running()

--- a/suricata_/suricata_.py
+++ b/suricata_/suricata_.py
@@ -178,8 +178,8 @@ class Suricata(ServiceBase):
     # Retry with exponential backoff until we can actually connect to the Suricata socket
     @retry(
         retry=retry_if_result(lambda x: x is False),
-        wait=wait_exponential(multiplier=1000, max=10000),
-        stop=stop_after_delay(120000),
+        wait=wait_exponential(multiplier=1, max=10),
+        stop=stop_after_delay(120),
     )
     def suricata_running_retry(self):
         return self.suricata_running()


### PR DESCRIPTION
This change switches the Suricata service to use [GitHub - Tenacity](https://github.com/jd/tenacity) instead of Retrying as Retrying has not been updated in 2 years and tenacity continues to receive updates and fixed bugs present in Retrying.

The retrying conditions have been ported to the syntax used by Tenacity and should function identically.
Lastly, I have updated the README to use an explicit Markdown codeblock, rather than it being tabbed it to create a code block.

I have run the service across the various testing PCAPs and experienced no errors or unexpected behaviour.